### PR TITLE
Bump required deepspeed version to match usage when saving checkpoints

### DIFF
--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -8,7 +8,7 @@ deps = {
     "cookiecutter": "cookiecutter==1.7.2",
     "dataclasses": "dataclasses",
     "datasets": "datasets",
-    "deepspeed": "deepspeed>=0.5.7",
+    "deepspeed": "deepspeed>=0.5.9",
     "fairscale": "fairscale>0.3",
     "faiss-cpu": "faiss-cpu",
     "fastapi": "fastapi",


### PR DESCRIPTION
Not much of a change, but required to close your PR to upstream.

@stas00 fyi